### PR TITLE
fix: DNS域名验证以及一键部署成功后，还是无法自动续期 #134

### DIFF
--- a/domain_admin/utils/acme_util/acme_v2_api.py
+++ b/domain_admin/utils/acme_util/acme_v2_api.py
@@ -343,7 +343,10 @@ def create_account(client_acme, directory_type=DirectoryTypeEnum.LETS_ENCRYPT):
 
 
 def get_acme_client(directory_type=DirectoryTypeEnum.LETS_ENCRYPT, key_type=KeyTypeEnum.RSA):
-    current_user_id = g.user_id
+    # 没有登录默认
+    current_user_id = 0
+    if g and hasattr(g, 'user_id'):
+        current_user_id = g.user_id
 
     # default use letsencrypt directory_url
     if not directory_type:


### PR DESCRIPTION
没登录情况下，默认登录用户id=0