### PR TITLE
支持纯ipv6域名做SSL证书到期检测

### DIFF
--- a/domain_admin/utils/cert_util/cert_openssl_v2.py
+++ b/domain_admin/utils/cert_util/cert_openssl_v2.py
@@ -73,11 +73,26 @@ def get_ssl_cert(
     """
     # 默认参数
     host = host or domain
+    # split port in domain
+    if ":" in host:
+        temp_list = host.split(":")
+        host = temp_list[0]
+        try:
+            port = int(temp_list[-1])
+        except Exception:
+            print("Illegal port ", temp_list[-1])
 
     # socket
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(timeout)
-    sock.connect((host, port))
+    # try ipv4
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect((host, port))
+    # try ipv6
+    except Exception:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect((host, port))
 
     # 用户可以设置使用协议：STARTTLS、SSL/TLS
     # issues: https://github.com/mouday/domain-admin/issues/57

--- a/domain_admin/utils/cert_util/cert_openssl_v2.py
+++ b/domain_admin/utils/cert_util/cert_openssl_v2.py
@@ -71,17 +71,20 @@ def get_ssl_cert(
     :param timeout: int
     :return:
     """
-    # 默认参数
-    host = host or domain
+    if domain.startswith("https://"):
+        domain = domain[len("https://"):]
+    if domain.startswith("http://"):
+        domain = domain[len("http://"):]
     # split port in domain
-    if ":" in host:
-        temp_list = host.split(":")
-        host = temp_list[0]
+    if ":" in domain:
+        temp_list = domain.split(":")
+        domain = temp_list[0]
         try:
             port = int(temp_list[-1])
         except Exception:
             print("Illegal port ", temp_list[-1])
-
+    # 默认参数
+    host = host or domain
     # socket
     # try ipv4
     try:

--- a/domain_admin/utils/cert_util/cert_socket_v2.py
+++ b/domain_admin/utils/cert_util/cert_socket_v2.py
@@ -24,12 +24,28 @@ def get_domain_host_list(domain, port=80):
     """
     # fix Python2 TypeError: getaddrinfo() takes no keyword arguments
     # host, port, family=None, socktype=None, proto=None, flags=None
-    ret = socket.getaddrinfo(
-        domain,
-        port,
-        socket.AF_INET,  # 限制仅返回IPv4
-        0,
-        socket.IPPROTO_TCP)
+    if domain.startswith("https://"):
+        domain = domain[len("https://"):]
+    if domain.startswith("http://"):
+        domain = domain[len("http://"):]
+    try:
+        # use ipv4
+        ret = socket.getaddrinfo(
+            domain,
+            port,
+            socket.AF_INET,  # 限制仅返回IPv4
+            0,
+            socket.IPPROTO_TCP
+        )
+    except Exception:
+        # use ipv6
+        ret = socket.getaddrinfo(
+            domain,
+            port,
+            socket.AF_INET6,
+            0,
+            socket.IPPROTO_TCP
+        )
 
     lst = []
     for item in ret:


### PR DESCRIPTION
以及`/api/getCertInformation`这个api，当输入的域名不是默认的443端口时，也可以正确返回证书信息