### PR TITLE
Fix acme_v2_api.py

### DIFF
--- a/domain_admin/utils/acme_util/acme_v2_api.py
+++ b/domain_admin/utils/acme_util/acme_v2_api.py
@@ -137,6 +137,14 @@ def new_csr_comp(domains, pkey_pem=None):
         pkey.generate_key(type=OpenSSL.crypto.TYPE_RSA, bits=CERT_PKEY_BITS)
         pkey_pem = OpenSSL.crypto.dump_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, pkey)
+    else:
+        # 如果调用传入的是 str，则转为 bytes
+        if isinstance(pkey_pem, str):
+            # 假设原始 str 是 UTF-8 编码的 PEM 文本
+            pkey_pem = pkey_pem.encode('utf-8')
+        # 如果传入的是 bytes，直接使用；若其他类型，可考虑报错或转换
+        if not isinstance(pkey_pem, (bytes, bytearray)):
+            raise TypeError(f"Unsupported type for pkey_pem: {type(pkey_pem)}")
 
     csr_pem = crypto_util.make_csr(pkey_pem, domains)
     return pkey_pem, csr_pem


### PR DESCRIPTION
修复申请证书时遇到的如下错误：
Fix error below:
```cmd
File "C:\ProgramData\miniconda3\Lib\site-packages\domain_admin\service\issue_certificate_service.py", line 76, in get_certificate_challenges
    pkey_pem, csr_pem = acme_v2_api.new_csr_comp(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\site-packages\domain_admin\utils\acme_util\acme_v2_api.py", line 141, in new_csr_comp
    csr_pem = crypto_util.make_csr(pkey_pem, domains)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\site-packages\acme\crypto_util.py", line 305, in make_csr
    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument 'data': from_buffer() cannot return the address of a unicode object
```