### PR TITLE
refactor(issue_certificate): 重构证书续签的验证逻辑，避免重复创建订单

### DIFF
--- a/domain_admin/api/issue_certificate_api.py
+++ b/domain_admin/api/issue_certificate_api.py
@@ -81,6 +81,24 @@ def verify_certificate():
         dns_id=dns_id
     )
 
+    if host_id and verify_deploy_path:
+        IssueCertificateModel.update(
+            challenge_deploy_type_id=ChallengeDeployTypeEnum.SSH,
+            challenge_deploy_id=host_id,
+            deploy_verify_path=verify_deploy_path,
+            challenge_deploy_status=DeployStatusEnum.SUCCESS
+        ).where(
+            IssueCertificateModel.id == issue_certificate_id
+        ).execute()
+    if dns_id:
+        IssueCertificateModel.update(
+            challenge_deploy_type_id=ChallengeDeployTypeEnum.DNS,
+            challenge_deploy_id=dns_id,
+            challenge_deploy_status=DeployStatusEnum.SUCCESS
+        ).where(
+            IssueCertificateModel.id == issue_certificate_id
+        ).execute()
+
     issue_certificate_service.renew_certificate(issue_certificate_id)
 
     # fix: 过滤通配符的域名

--- a/domain_admin/service/issue_certificate_service.py
+++ b/domain_admin/service/issue_certificate_service.py
@@ -306,35 +306,14 @@ def renew_certificate_row(row):
         IssueCertificateModel.id == row.id
     )
 
-    # 验证文件部署
-    if row.challenge_deploy_type_id == ChallengeDeployTypeEnum.SSH:
-        # 获取验证方式
-        challenge_list = get_certificate_challenges(row.id)
-
-        challenge_rows = []
-        for challenge_row in challenge_list:
-            challenge_json = challenge_row['challenge'].to_json()
-            if challenge_json['type'] == ChallengeType.HTTP01:
-                challenge_rows.append({
-                    'token': challenge_json['token'],
-                    'validation': challenge_row['validation']
-                })
-
-        deploy_verify_file(
-            host_id=row.challenge_deploy_id,
-            verify_deploy_path=row.deploy_verify_path,
-            challenges=challenge_rows
-        )
-    elif row.challenge_deploy_type_id == ChallengeDeployTypeEnum.DNS:
-        challenge_list = get_certificate_challenges(row.id)
-        # 添加txt记录
-        add_dns_domain_record(
-            dns_id=row.challenge_deploy_id,
-            challenges=challenge_list
-        )
-
-    # 验证域名
-    verify_certificate(row.id, row.challenge_type)
+    # 验证文件部署 & 验证域名
+    verify_certificate(
+        issue_certificate_id=row.id,
+        challenge_type=row.challenge_type,
+        verify_deploy_path=row.deploy_verify_path,
+        host_id=row.challenge_deploy_id,
+        dns_id=row.challenge_deploy_id
+    )
 
     # 下载证书
     renew_certificate(row.id)


### PR DESCRIPTION
通过统一的证书验证部署方式简化验证流程，提高代码可维护性。