### PR TITLE
feat: 实现 DNS 与服务器主机关联功能及自动续期结果展示

### DIFF
--- a/domain_admin/api/host_api.py
+++ b/domain_admin/api/host_api.py
@@ -28,6 +28,7 @@ def add_host():
     auth_type = request.json['auth_type']
     private_key = request.json['private_key']
     password = request.json['password']
+    dns_id = request.json.get('dns_id', 0)
 
     row = HostModel.create(
         user_id=current_user_id,
@@ -37,6 +38,7 @@ def add_host():
         auth_type=auth_type,
         private_key=private_key,
         password=password,
+        dns_id=dns_id
     )
 
     return row
@@ -57,6 +59,7 @@ def update_host_by_id():
     password = request.json['password']
     auth_type = request.json['auth_type']
     private_key = request.json['private_key']
+    dns_id = request.json.get('dns_id', 0)
 
     # check data
     host_row = HostModel.select().where(
@@ -74,6 +77,7 @@ def update_host_by_id():
         password=password,
         auth_type=auth_type,
         private_key=private_key,
+        dns_id=dns_id
     ).where(
         HostModel.id == host_row.id
     ).execute()

--- a/domain_admin/model/host_model.py
+++ b/domain_admin/model/host_model.py
@@ -39,6 +39,9 @@ class HostModel(BaseModel):
     private_key = TextField(default=None, null=True)
 
     password = CharField(default=None, null=True)
+    
+    # DNS账号id @since v1.6.xx
+    dns_id = IntegerField(default=0)
 
     # 创建时间
     create_time = DateTimeField(default=datetime.now)

--- a/domain_admin/model/issue_certificate_model.py
+++ b/domain_admin/model/issue_certificate_model.py
@@ -123,6 +123,12 @@ class IssueCertificateModel(BaseModel):
     # 自动续期
     is_auto_renew = BooleanField(default=False)
 
+    # 续期执行状态 0：成功，1：失败
+    renew_status = IntegerField(default=0)
+
+    # 续期失败信息
+    renew_message = TextField(default=None, null=True)
+
     # 数据版本号
     version = IntegerField(default=0, null=False)
 

--- a/domain_admin/service/issue_certificate_service.py
+++ b/domain_admin/service/issue_certificate_service.py
@@ -281,8 +281,25 @@ def renew_all_certificate():
     for row in rows:
         try:
             renew_certificate_row(row)
+
+            IssueCertificateModel.update(
+                renew_status=0,
+                renew_message='成功',
+                update_time=datetime.now()
+            ).where(
+                IssueCertificateModel.id == row.id
+            ).execute()
+
         except Exception as e:
             logger.error(traceback.format_exc())
+
+            IssueCertificateModel.update(
+                renew_status=1,
+                renew_message=str(e),
+                update_time=datetime.now()
+            ).where(
+                IssueCertificateModel.id == row.id
+            ).execute()
 
 
 def renew_certificate_row(row):


### PR DESCRIPTION
# 背景与目的：
> 为了提升证书自动化管理效率，本次改动在系统中引入了“DNS 账号”与“服务器主机”的关联机制。该机制允许系统在检测到证书验证/部署目标时，能够自动识别并联动相关的配置。同时，增加了对自动续期执行结果的追溯能力，方便用户直观查看续期状态和错误原因。

## 后端改动 (domain-admin)
1. 模型层更新：
HostModel: 新增 dns_id 字段，实现服务器主机与 DNS 账号的绑定。
IssueCertificateModel: 新增 renew_status (续期状态) 和 renew_message (报错信息) 字段。
2. API 增强：
host_api.py: add_host 和 update_host_by_id 接口支持 dns_id 的读写。
issue_certificate_api.py: get_issue_certificate_list
接口支持返回关联的 DNS/主机名称，优化列表展示性能。
get_issue_certificate_by_id
 支持根据主机关联关系自动加载 DNS 配置。
3. 服务层优化：
issue_certificate_service.py : 完善 renew_all_certificate
 逻辑，在续期任务执行成功或捕获异常时，自动持久化结果到数据库。
## 前端改动 (domain-admin-web)
1. 主机管理优化：
在“添加/编辑主机”表单中新增“关联 DNS 账号”下拉选框。
2. 证书申请流程联动：
在证书申请的“文件验证”步骤中，选择主机后会自动检测其关联的 DNS 账号，并提供“一键切换至 DNS 验证”的快捷入口。
3. 证书列表视觉增强：
新增“关联信息”列：以“DNS账号/部署主机”格式直观展示每条证书的去向。
续期结果可视化：在自动续期开关下方实时展示续期结果标签（成功/失败）。针对失败记录，支持鼠标悬停通过 Tooltip 查看具体错误日志。