### PR TITLE
feat: 新增单点登录功能

### DIFF
--- a/OIDC_CONFIG.md
+++ b/OIDC_CONFIG.md
@@ -1,0 +1,55 @@
+# OpenID Connect (OIDC) 单点登录配置指南
+
+本项目已集成 OpenID Connect (OIDC) 单点登录功能，支持 pocket-id 等 OIDC 提供商。
+
+## 功能特性
+
+- 使用 authlib 库实现标准 OIDC 协议
+- 支持自动创建用户账号
+- 不修改现有数据模型
+- 与现有 JWT 认证系统无缝集成
+
+## 配置方式
+
+### 1. 环境变量配置
+
+在 `.env` 文件中添加以下配置：
+
+```bash
+# 启用 OIDC 单点登录
+OIDC_ENABLED=true
+
+# OIDC 客户端 ID（必填）
+OIDC_CLIENT_ID=your_client_id
+
+# OIDC 客户端密钥（必填）
+OIDC_CLIENT_SECRET=your_client_secret
+
+# OIDC 提供商的 Issuer URL（必填，不包含 .well-known/openid-configuration）
+OIDC_ISSUER_URL=https://your-oidc-provider.com
+
+# OIDC 请求的权限范围（可选，默认为 "openid profile email"）
+OIDC_SCOPES=openid profile email
+
+# 自动创建用户的默认角色（可选，默认为 1）
+# 1 = 普通用户（RoleEnum.USER）
+# 10 = 管理员（RoleEnum.ADMIN）
+OIDC_AUTO_CREATE_USER_ROLE=1
+
+# 自动创建用户的默认状态（可选，默认为 false）
+# true = 启用账号
+# false = 禁用账号（需要管理员手动启用）
+OIDC_AUTO_CREATE_USER_STATUS=false
+```
+
+**重要说明**:
+- 回调地址由系统自动生成（`/api/oidc/callback`），无需手动配置
+- 在 OIDC 提供商中配置回调地址时，使用完整 URL，例如：`https://xxx.com/api/oidc/callback`
+- 生产环境建议使用 HTTPS 协议
+
+## 注意事项
+
+1. 本实现尽可能不修改现有数据模型，OIDC 用户使用现有的 `UserModel`
+2. OIDC 用户的 `password` 字段为空字符串，不影响系统功能
+3. 用户可以同时使用 OIDC 登录和传统登录（如果管理员为 OIDC 用户设置了密码）
+4. 系统会自动处理用户创建和更新，无需手动干预

--- a/domain_admin/api/oidc_api.py
+++ b/domain_admin/api/oidc_api.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""
+oidc_api.py
+OpenID Connect API 端点
+"""
+from __future__ import print_function, unicode_literals, absolute_import, division
+
+from flask import redirect
+
+from domain_admin.service import oidc_service
+from domain_admin.utils.flask_ext.app_exception import AppException
+
+
+def oidc_config():
+    """
+    获取 OIDC 配置信息
+    返回给前端，用于判断是否显示 OIDC 登录按钮
+    """
+    return {
+        'enabled': oidc_service.is_oidc_enabled()
+    }
+
+
+def oidc_login():
+    """
+    发起 OIDC 登录
+    重定向到 OIDC 提供商的授权页面
+    """
+    # 检查 OIDC 是否启用
+    if not oidc_service.is_oidc_enabled():
+        raise AppException('OIDC 单点登录未启用')
+
+    # 生成授权 URL 并重定向（authlib 自动处理 state）
+    return oidc_service.get_authorization_url()
+
+
+def oidc_callback():
+    """
+    OIDC 回调端点
+    处理 OIDC 提供商的回调，完成登录
+    """
+    # 检查 OIDC 是否启用
+    if not oidc_service.is_oidc_enabled():
+        raise AppException('OIDC 单点登录未启用')
+
+    # 处理回调，获取 token（authlib 自动处理授权码交换和 state 验证）
+    jwt_token = oidc_service.handle_callback()
+
+    # 调试时注意跳转的地址是否正确
+    redirect_url = f"/?token={jwt_token}"
+    return redirect(redirect_url)

--- a/domain_admin/config/default_config.py
+++ b/domain_admin/config/default_config.py
@@ -47,3 +47,6 @@ USER_AGENT = "Mozilla/5.0 (compatible; DomainAdmin/{version}; +{url})".format(
     version=VERSION,
     url=PROJECT_HOME_URL,
 )
+
+# 是否启用单点登录
+OIDC_ENABLED = False

--- a/domain_admin/config/env_config.py
+++ b/domain_admin/config/env_config.py
@@ -36,3 +36,14 @@ ALLOW_COMMANDS = [cmd.strip() for cmd in env.str("ALLOW_COMMANDS", '').split(';'
 
 # ENABLED_REGISTER
 ENABLED_REGISTER = env.bool("ENABLED_REGISTER", False)
+
+# OIDC 单点登录配置
+OIDC_ENABLED = env.bool("OIDC_ENABLED", OIDC_ENABLED)
+OIDC_CLIENT_ID = env.str("OIDC_CLIENT_ID", "")
+OIDC_CLIENT_SECRET = env.str("OIDC_CLIENT_SECRET", "")
+OIDC_ISSUER_URL = env.str("OIDC_ISSUER_URL", "")
+OIDC_SCOPES = env.str("OIDC_SCOPES", "openid profile email")
+
+# OIDC 自动创建用户的默认配置
+OIDC_AUTO_CREATE_USER_ROLE = env.int("OIDC_AUTO_CREATE_USER_ROLE", 1)  # 1=USER, 10=ADMIN
+OIDC_AUTO_CREATE_USER_STATUS = env.bool("OIDC_AUTO_CREATE_USER_STATUS", False)

--- a/domain_admin/main.py
+++ b/domain_admin/main.py
@@ -88,6 +88,10 @@ def init_app(flask_app):
     """
     logger.info('init_app')
 
+    # 设置 SECRET_KEY（必须在注册路由之前设置，因为 OIDC 需要使用 session）
+    from domain_admin.config import SECRET_KEY
+    flask_app.config['SECRET_KEY'] = SECRET_KEY
+
     # 注册路由
     register.register_app_routers(flask_app, api_map.routes)
 
@@ -116,6 +120,10 @@ def init_app(flask_app):
 
     # 初始化全局常量配置
     system_service.init_system_config(flask_app)
+
+    # 初始化 OIDC 单点登录
+    from domain_admin.service import oidc_service
+    oidc_service.init_oidc(flask_app)
 
     # 尝试更新whois_servers文件
     # try:

--- a/domain_admin/router/api_map.py
+++ b/domain_admin/router/api_map.py
@@ -15,7 +15,7 @@ from domain_admin.api import (
     domain_api, group_api,
     auth_api, system_api,
     user_api, log_scheduler_api,
-    check_wechat_api
+    check_wechat_api, oidc_api
 )
 
 routes = {
@@ -241,4 +241,9 @@ routes = {
 
     # 微信域名禁封状态检查
     '/api/validateUrlForWechat': check_wechat_api.validate_url_for_wechat,
+
+    # OIDC SSO
+    '/api/oidc/login': oidc_api.oidc_login,
+    '/api/oidc/callback': oidc_api.oidc_callback,
+    '/api/oidc/config': oidc_api.oidc_config,
 }

--- a/domain_admin/router/permission.py
+++ b/domain_admin/router/permission.py
@@ -14,6 +14,10 @@ WHITE_LIST = [
     # 暂时不开放注册，安全起见先关闭
     '/api/register',
     '/api/getSystemVersion',
+    # OIDC SSO endpoints
+    '/api/oidc/login',
+    '/api/oidc/callback',
+    '/api/oidc/config',
 ]
 
 # 仅管理账号可访问的接口

--- a/domain_admin/service/oidc_service.py
+++ b/domain_admin/service/oidc_service.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+oidc_service.py
+OpenID Connect 单点登录服务
+"""
+from __future__ import print_function, unicode_literals, absolute_import, division
+
+from authlib.integrations.flask_client import OAuth
+from flask import url_for
+
+from domain_admin.log import logger
+from domain_admin.model.user_model import UserModel
+from domain_admin.service import token_service
+from domain_admin.utils.flask_ext.app_exception import AppException
+
+# OAuth 实例
+oauth = OAuth()
+
+
+def init_oidc(app):
+    """
+    初始化 OIDC OAuth 客户端
+    :param app: Flask 应用实例
+    """
+    try:
+        if not is_oidc_enabled():
+            logger.info("OIDC 单点登录未启用，跳过初始化")
+            return
+
+        # 初始化 OAuth
+        oauth.init_app(app)
+
+        # 获取配置
+        config = get_oidc_config()
+        client_id = config.get('client_id')
+        client_secret = config.get('client_secret')
+        issuer_url = config.get('issuer_url')
+        scopes = config.get('scopes', 'openid profile email')
+
+        if not all([client_id, client_secret, issuer_url]):
+            logger.warning("OIDC 配置不完整，跳过初始化")
+            return
+
+        # 注册 OIDC 客户端（authlib 会自动存储，可通过 oauth.oidc 访问）
+        oauth.register(
+            name='oidc',
+            client_id=client_id,
+            client_secret=client_secret,
+            server_metadata_url=f"{issuer_url}/.well-known/openid-configuration",
+            client_kwargs={
+                'scope': scopes
+            }
+        )
+
+        logger.info("OIDC OAuth 客户端初始化成功")
+
+    except Exception as e:
+        logger.error(f"OIDC 初始化失败: {str(e)}")
+        # 优雅降级 - 不让应用崩溃
+
+
+def is_oidc_enabled():
+    """
+    检查 OIDC 是否启用
+    :return: bool
+    """
+    from domain_admin.config import OIDC_ENABLED
+    return OIDC_ENABLED
+
+
+def get_oidc_config():
+    """
+    Get OIDC configuration from environment variables
+    :return: dict with keys: issuer_url, client_id, client_secret, scopes
+    """
+    from domain_admin.config import (
+        OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_SCOPES,
+        OIDC_AUTO_CREATE_USER_ROLE, OIDC_AUTO_CREATE_USER_STATUS
+    )
+
+    return {
+        'issuer_url': OIDC_ISSUER_URL,
+        'client_id': OIDC_CLIENT_ID,
+        'client_secret': OIDC_CLIENT_SECRET,
+        'scopes': OIDC_SCOPES,
+        'auto_create_user_role': OIDC_AUTO_CREATE_USER_ROLE,
+        'auto_create_user_status': OIDC_AUTO_CREATE_USER_STATUS
+    }
+
+
+def get_authorization_url():
+    """
+    生成授权 URL 并重定向
+    :return: Flask redirect response
+    """
+    if not hasattr(oauth, 'oidc'):
+        raise AppException("OIDC 客户端未初始化")
+
+    # 动态构建完整的 redirect_uri
+    # 使用 url_for 生成回调地址，_external=True 生成完整 URL
+    redirect_uri = url_for('oidc_callback', _external=True)
+    return oauth.oidc.authorize_redirect(redirect_uri)
+
+
+def handle_callback():
+    """
+    处理 OIDC 回调
+    :return: JWT token
+    """
+    if not hasattr(oauth, 'oidc'):
+        raise AppException("OIDC 客户端未初始化")
+
+    try:
+        logger.info("开始处理 OIDC 回调")
+
+        # 交换授权码获取 token
+        token = oauth.oidc.authorize_access_token()
+        logger.info(f"Token 交换成功，token keys: {token.keys() if token else 'None'}")
+
+        # 获取用户信息
+        userinfo = token.get('userinfo')
+        if not userinfo:
+            # 如果 token 中没有 userinfo，从 userinfo 端点获取
+            logger.info("从 userinfo 端点获取用户信息")
+            userinfo = oauth.oidc.userinfo(token=token)
+
+        logger.info(f"用户信息获取成功: {userinfo.keys() if userinfo else 'None'}")
+
+        # 处理用户登录或注册
+        return process_oidc_user(userinfo)
+
+    except AppException:
+        raise
+    except Exception as e:
+        logger.error(f"OIDC 回调处理失败: {str(e)}")
+        raise AppException(f"OIDC 认证失败: {str(e)}")
+
+
+def process_oidc_user(userinfo):
+    """
+    处理 OIDC 用户信息，创建或更新用户
+    :param userinfo: OIDC 用户信息
+    :return: JWT token
+    """
+    # 从 userinfo 中提取用户标识
+    # 优先使用 preferred_username，其次使用 email，最后使用 sub
+    username = userinfo.get('preferred_username') or userinfo.get('email') or userinfo.get('sub')
+
+    if not username:
+        raise AppException('无法从 OIDC 提供商获取用户标识')
+
+    logger.info(f"处理 OIDC 用户: {username}")
+
+    # 查找或创建用户
+    user_row = UserModel.select().where(
+        UserModel.username == username
+    ).get_or_none()
+
+    if not user_row:
+        # 自动创建用户
+        oidc_config = get_oidc_config()
+        user_row = UserModel.create(
+            username=username,
+            password='',  # OIDC 用户不需要密码
+            role=oidc_config['auto_create_user_role'],
+            status=oidc_config['auto_create_user_status'],
+            avatar_url=userinfo.get('picture', '')
+        )
+        logger.info(f"创建新用户: {username}")
+    else:
+        logger.info(f"用户已存在: {username}")
+
+    # 生成 JWT token
+    return token_service.encode_token({
+        'user_id': user_row.id
+    })

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -26,3 +26,4 @@ alibabacloud_cas20200407==1.4.0
 alibabacloud_dcdn20180115==2.4.0
 oss2
 diskcache
+Authlib


### PR DESCRIPTION
# OpenID Connect (OIDC) 单点登录配置指南

本项目已集成 OpenID Connect (OIDC) 单点登录功能，支持 pocket-id 等 OIDC 提供商。

## 功能特性

- 使用 authlib 库实现标准 OIDC 协议
- 支持自动创建用户账号
- 不修改现有数据模型
- 与现有 JWT 认证系统无缝集成

## 配置方式

### 1. 环境变量配置

在 `.env` 文件中添加以下配置：

```bash
# 启用 OIDC 单点登录
OIDC_ENABLED=true

# OIDC 客户端 ID（必填）
OIDC_CLIENT_ID=your_client_id

# OIDC 客户端密钥（必填）
OIDC_CLIENT_SECRET=your_client_secret

# OIDC 提供商的 Issuer URL（必填，不包含 .well-known/openid-configuration）
OIDC_ISSUER_URL=https://your-oidc-provider.com

# OIDC 请求的权限范围（可选，默认为 "openid profile email"）
OIDC_SCOPES=openid profile email

# 自动创建用户的默认角色（可选，默认为 1）
# 1 = 普通用户（RoleEnum.USER）
# 10 = 管理员（RoleEnum.ADMIN）
OIDC_AUTO_CREATE_USER_ROLE=1

# 自动创建用户的默认状态（可选，默认为 false）
# true = 启用账号
# false = 禁用账号（需要管理员手动启用）
OIDC_AUTO_CREATE_USER_STATUS=false
```

**重要说明**:
- 回调地址由系统自动生成（`/api/oidc/callback`），无需手动配置
- 在 OIDC 提供商中配置回调地址时，使用完整 URL，例如：`https://xxx.com/api/oidc/callback`
- 生产环境建议使用 HTTPS 协议

## 注意事项

1. 本实现尽可能不修改现有数据模型，OIDC 用户使用现有的 `UserModel`
2. OIDC 用户的 `password` 字段为空字符串，不影响系统功能
3. 用户可以同时使用 OIDC 登录和传统登录（如果管理员为 OIDC 用户设置了密码）
4. 系统会自动处理用户创建和更新，无需手动干预
